### PR TITLE
docs(examples/ts): add TypeScript example for deploying a job

### DIFF
--- a/examples/nodejs/with-typescript/README.md
+++ b/examples/nodejs/with-typescript/README.md
@@ -1,0 +1,26 @@
+# TypeScript DCP Client example
+
+This is an example project that shows the usage of DCP Client with TypeScript.
+
+To run this example:
+
+```console
+npm install
+npm run start
+```
+
+## Notes
+
+This example shows how to use DCP Client with the TypeScript type system to
+deploy a job. For example's sake, the project uses `ts-node` to run the example
+program.
+
+```console
+npm install ts-node
+```
+
+To enable TypeScript's features, install the type declarations for DCP Client.
+
+```console
+npm install --save-dev @types/dcp-client
+```

--- a/examples/nodejs/with-typescript/main.ts
+++ b/examples/nodejs/with-typescript/main.ts
@@ -1,0 +1,29 @@
+// How to deploy a job using TypeScript.
+
+import { init } from 'dcp-client';
+
+const { compute } = await init();
+
+const inputSet = [1, 2, 3, 4];
+
+const workFunction = (input) => {
+  // Send a mandatory progress update to the scheduler.
+  progress();
+  return input ** 2;
+};
+
+const job = compute.for(inputSet, workFunction);
+
+job.public.name = 'TypeScript example';
+
+job.on('accepted', () => {
+  console.log('Job accepted with id:', job.id);
+});
+
+job.on('result', ({ result }) => {
+  console.log('Received a result:', result);
+});
+
+const results = await job.exec();
+
+console.log(results);

--- a/examples/nodejs/with-typescript/package.json
+++ b/examples/nodejs/with-typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "ts-node main.ts"
+  },
+  "dependencies": {
+    "dcp-client": "latest"
+  },
+  "devDependencies": {
+    "@types/dcp-client": "latest",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.8.3"
+  }
+}

--- a/examples/nodejs/with-typescript/tsconfig.json
+++ b/examples/nodejs/with-typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext"
+  }
+}


### PR DESCRIPTION
With the creation of [@types/dcp-client](https://www.npmjs.com/package/@types/dcp-client) (thank you @roman5364!), I've added an example for deploying jobs on DCP with the client library in TypeScript to act as smoke tests for `@types/dcp-client` based on the updated package in DefinitelyTyped/DefinitelyTyped#62244.

Currently, there are TS compilation errors from normal usage of the library indicating that some modifications to DefinitelyTyped/DefinitelyTyped#62244 are required. e.g.,

<details>
<summary>Error output</summary>

```console
$ npm start --silent
/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
main.ts:11:3 - error TS2552: Cannot find name 'progress'. Did you mean 'onprogress'?

11   progress();
     ~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:17931:13
    17931 declare var onprogress: ((this: Window, ev: ProgressEvent) => any) | null;
                      ~~~~~~~~~~
    'onprogress' is declared here.
main.ts:15:21 - error TS2554: Expected 3-5 arguments, but got 2.

15 const job = compute.for(inputSet, workFunction);
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/@types/dcp-client/index.d.ts:70:53
    70     for(rangeObject: object | Ranges, work: string, arguments: object): Promise<JobHandle>;
                                                           ~~~~~~~~~~~~~~~~~
    An argument for 'arguments' was not provided.
main.ts:17:5 - error TS2339: Property 'public' does not exist on type 'Promise<JobHandle>'.

17 job.public.name = 'TypeScript example';
       ~~~~~~

  main.ts:17:5
    17 job.public.name = 'TypeScript example';
           ~~~~~~
    Did you forget to use 'await'?
main.ts:19:5 - error TS2339: Property 'on' does not exist on type 'Promise<JobHandle>'.

19 job.on('accepted', () => {
       ~~

  main.ts:19:5
    19 job.on('accepted', () => {
           ~~
    Did you forget to use 'await'?
main.ts:20:43 - error TS2339: Property 'id' does not exist on type 'Promise<JobHandle>'.

20   console.log('Job accepted with id', job.id);
                                             ~~
main.ts:23:5 - error TS2339: Property 'on' does not exist on type 'Promise<JobHandle>'.

23 job.on('result', ({ result }) => {
       ~~

  main.ts:23:5
    23 job.on('result', ({ result }) => {
           ~~
    Did you forget to use 'await'?
main.ts:27:27 - error TS2339: Property 'exec' does not exist on type 'Promise<JobHandle>'.

27 const results = await job.exec();
                             ~~~~

  main.ts:27:27
    27 const results = await job.exec();
                                 ~~~~
    Did you forget to use 'await'?

    at createTSError (/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Object.require.extensions.<computed> [as .ts] (/home/bryan/git/gitlab.com/Distributed-Compute-Protocol/dcp-client/examples/nodejs/with-typescript/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12) {
  diagnosticCodes: [
    2552, 2554,
    2339, 2339,
    2339, 2339,
    2339
  ]
}
```

</details>