### PR TITLE
docs(examples/ts): add TypeScript example for deploying a job

### DIFF
--- a/examples/nodejs/with-typescript/README.md
+++ b/examples/nodejs/with-typescript/README.md
@@ -1,0 +1,26 @@
+# TypeScript DCP Client example
+
+This is an example project that shows the usage of DCP Client with TypeScript.
+
+To run this example:
+
+```console
+npm install
+npm run start
+```
+
+## Notes
+
+This example shows how to use DCP Client with the TypeScript type system to
+deploy a job. For example's sake, the project uses `ts-node` to run the example
+program.
+
+```console
+npm install ts-node
+```
+
+To enable TypeScript's features, install the type declarations for DCP Client.
+
+```console
+npm install --save-dev @types/dcp-client
+```

--- a/examples/nodejs/with-typescript/main.ts
+++ b/examples/nodejs/with-typescript/main.ts
@@ -1,0 +1,30 @@
+// How to deploy a job using TypeScript.
+
+import { init } from 'dcp-client';
+
+const { compute } = await init();
+
+const inputSet = [1, 2, 3, 4];
+
+const workFunction = (input: number) => {
+  // Send a mandatory progress update to the scheduler.
+  progress();
+
+  return input ** 2;
+};
+
+const job = compute.for(inputSet, workFunction);
+
+job.public.name = 'TypeScript example';
+
+job.on('accepted', () => {
+  console.log('Job accepted with id:', job.id);
+});
+
+job.on('result', ({ result }) => {
+  console.log('Received a result:', result);
+});
+
+const results = await job.exec();
+
+console.log(results);

--- a/examples/nodejs/with-typescript/package.json
+++ b/examples/nodejs/with-typescript/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "ts-node main.ts"
+  },
+  "dependencies": {
+    "dcp-client": "latest"
+  },
+  "devDependencies": {
+    "@types/dcp-client": "latest",
+    "ts-node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/examples/nodejs/with-typescript/tsconfig.json
+++ b/examples/nodejs/with-typescript/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext"
+  },
+  "ts-node": {
+    "esm": true
+  }
+}


### PR DESCRIPTION
Adds an example for deploying jobs on DCP with the client library in TypeScript now that the `@types/dcp-client` package exists (defined in https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/dcp-client).

Related PR: DefinitelyTyped/DefinitelyTyped#64326.